### PR TITLE
Add Audit Events

### DIFF
--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -98,7 +98,11 @@ enum SyncType {
 
   // Delete all previously received rules before applying the newly received rules.
   CLEAN_ALL = 3;
-  clean_all = 3 [deprecated = true];
+  clean_all = 3 [deprecated=true];
+
+  // Delete all rules created in Standalone mode before applying the newly
+  // received rules.
+  CLEAN_STANDALONE = 4;
 }
 
 enum FileAccessAction {
@@ -178,6 +182,11 @@ message PreflightResponse {
   //   `auditonly`: Actions that would be denied are logged but allowed
   //   `none`: The policy will be applied as written
   optional FileAccessAction override_file_access_action = 15;
+
+  // If set, this will put Santa into standalone mode, where a user can approve
+  // binaries from unknown blocks with TouchID. If set to false, Santa will
+  // revert back to normal operation.
+  optional bool standalone_mode = 16;
 
   // These fields are deprecated forms of other fields and exist here solely for backwards compatibility
   optional bool deprecated_enabled_transitive_whitelisting = 1000 [
@@ -284,17 +293,18 @@ message Event {
   repeated Certificate signing_chain = 28 [json_name = "signing_chain"];
 }
 
-// AuditE
-message NewStandaloneModeRuleCreation {
-  Decision decision = 1; // Indicates new rule type
-  string identifier = 2; // Indicates new rule identifier
-  uint32 timestamp  = 3; // Timestamp of rule creation
+// Audit Event for when Santa makes a new rule in standalone mode.
+message StandaloneModeRuleCreation {
+  Decision decision = 1 [json_name="decision"];   // Indicates new rule type
+  string identifier = 2 [json_name="identifier"]; // Indicates new rule identifier
+  uint32 timestamp  = 3 [json_name="timestamp"];  // Timestamp of rule creation
 }
 
-// AuditEvents are events sent by Santa such as standalone mode rule creation.
+// AuditEvents are events sent by Santa to communicate context to the sync
+// service.
 message AuditEvents {
    oneof event {
-      NewStandaloneModeRule new_standalonemode_rule = 1;
+      StandaloneModeRuleCreation standalone_mode_rule_creation = 1 [json_name="standalone_mode_rule_creation"];
    }
 }
 

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -302,7 +302,7 @@ message StandaloneModeRuleCreation {
 
 // AuditEvents are events sent by Santa to communicate context to the sync
 // service.
-message AuditEvents {
+message AuditEvent {
    oneof event {
       StandaloneModeRuleCreation standalone_mode_rule_creation = 1 [json_name="standalone_mode_rule_creation"];
    }

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -99,7 +99,7 @@ enum SyncType {
 
   // Delete all previously received rules before applying the newly received rules.
   CLEAN_ALL = 3;
-  clean_all = 3 [deprecated=true];
+  clean_all = 3 [deprecated = true];
 
   // Delete all rules created in Standalone mode before applying the newly
   // received rules.
@@ -291,24 +291,24 @@ message Event {
 
 // Audit Event for when Santa makes a new rule in standalone mode.
 message StandaloneModeRuleCreation {
-  Decision decision = 1 [json_name="decision"];   // Indicates new rule type
-  string identifier = 2 [json_name="identifier"]; // Indicates new rule identifier
-  uint32 timestamp  = 3 [json_name="timestamp"];  // Timestamp of rule creation
+  Decision decision = 1 [json_name = "decision"]; // Indicates new rule type
+  string identifier = 2 [json_name = "identifier"]; // Indicates new rule identifier
+  uint32 timestamp = 3 [json_name = "timestamp"]; // Timestamp of rule creation
 }
 
 // AuditEvents are events sent by Santa to communicate context to the sync
 // service.
 message AuditEvent {
-   oneof event {
-      StandaloneModeRuleCreation standalone_mode_rule_creation = 1 [json_name="standalone_mode_rule_creation"];
-   }
+  oneof event {
+    StandaloneModeRuleCreation standalone_mode_rule_creation = 1 [json_name = "standalone_mode_rule_creation"];
+  }
 }
 
 message EventUploadRequest {
-  repeated Event events = 1             [json_name = "events"];
-  repeated AuditEvent audit_events = 3  [json_name="audit_events"];
+  repeated Event events = 1 [json_name = "events"];
+  repeated AuditEvent audit_events = 3 [json_name = "audit_events"];
   // The UUID of the machine where the event(s) occurred
-  string machine_id = 2                 [json_name = "machine_id"];
+  string machine_id = 2 [json_name = "machine_id"];
 }
 
 message EventUploadResponse {

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -56,6 +56,7 @@ enum ClientMode {
   UNKNOWN_CLIENT_MODE = 0;
   MONITOR = 1;
   LOCKDOWN = 2;
+  STANDALONE = 3;
 }
 
 message PreflightRequest {
@@ -182,11 +183,6 @@ message PreflightResponse {
   //   `auditonly`: Actions that would be denied are logged but allowed
   //   `none`: The policy will be applied as written
   optional FileAccessAction override_file_access_action = 15;
-
-  // If set, this will put Santa into standalone mode, where a user can approve
-  // binaries from unknown blocks with TouchID. If set to false, Santa will
-  // revert back to normal operation.
-  optional bool standalone_mode = 16;
 
   // These fields are deprecated forms of other fields and exist here solely for backwards compatibility
   optional bool deprecated_enabled_transitive_whitelisting = 1000 [

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -284,10 +284,25 @@ message Event {
   repeated Certificate signing_chain = 28 [json_name = "signing_chain"];
 }
 
+// AuditE
+message NewStandaloneModeRuleCreation {
+  Decision decision = 1; // Indicates new rule type
+  string identifier = 2; // Indicates new rule identifier
+  uint32 timestamp  = 3; // Timestamp of rule creation
+}
+
+// AuditEvents are events sent by Santa such as standalone mode rule creation.
+message AuditEvents {
+   oneof event {
+      NewStandaloneModeRule new_standalonemode_rule = 1;
+   }
+}
+
 message EventUploadRequest {
-  repeated Event events = 1 [json_name = "events"];
+  repeated Event events = 1             [json_name = "events"];
+  repeated AuditEvent audit_events = 3; [json_name="audit_events"];
   // The UUID of the machine where the event(s) occurred
-  string machine_id = 2 [json_name = "machine_id"];
+  string machine_id = 2                 [json_name = "machine_id"];
 }
 
 message EventUploadResponse {

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -310,7 +310,7 @@ message AuditEvent {
 
 message EventUploadRequest {
   repeated Event events = 1             [json_name = "events"];
-  repeated AuditEvent audit_events = 3; [json_name="audit_events"];
+  repeated AuditEvent audit_events = 3  [json_name="audit_events"];
   // The UUID of the machine where the event(s) occurred
   string machine_id = 2                 [json_name = "machine_id"];
 }


### PR DESCRIPTION
This PR does the following:
 -  Adds a standalone mode to the ClientMode enum.
 -  Adds a new event type to the EventUpload stage called an audit event

It is part of the Standalone Mode work for https://github.com/northpolesec/santa/issues/132 and is blocking https://github.com/northpolesec/santa/pull/86