### PR TITLE
sync/syncv2: Add BLOCK_BINARY_MISMATCH decision

### DIFF
--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -476,6 +476,10 @@ enum Decision {
   // Provided by sync v2
   reserved "ALLOW_CEL_FALLBACK", "BLOCK_CEL_FALLBACK";
   reserved 16 to 17;
+
+  // The execution was blocked because the kernel's view of the binary
+  // disagreed with Santa's on-disk view at policy-evaluation time.
+  BLOCK_BINARY_MISMATCH = 18;
 }
 
 message Certificate {

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -552,6 +552,10 @@ enum Decision {
 
   // The execution was blocked because of a CEL fallback rule.
   BLOCK_CEL_FALLBACK = 17;
+
+  // The execution was blocked because the kernel's view of the binary
+  // disagreed with Santa's on-disk view at policy-evaluation time.
+  BLOCK_BINARY_MISMATCH = 18;
 }
 
 message Certificate {


### PR DESCRIPTION
Used by Santa when the kernel's view of the about-to-execute binary disagrees with Santa's on-disk view at policy-evaluation time.