### PR TITLE
sleighconfig: Move to top-level command oneof

### DIFF
--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -57,5 +57,5 @@ message SleighConfig {
 
   oneof command {
     SleighExportTelemetry export_telemetry = 3;
-  };
+  }
 }

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -49,7 +49,6 @@ message SleighExportTelemetry {
 // Sleigh is started.
 message SleighConfig {
   // The host_id for this host as sent up to Workshop.
-  // the export folder.
   string host_id = 1;
 
   // The host_name for this host as sent up to Workshop.

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -25,37 +25,37 @@ message SignedPost {
   // POST URL to send the signed form values and desired data. Use content type
   // multipart/form-data when making the request.
   string url = 1;
+
   // Signed values which authorize the POST request. Append the desired object
   // name to the "key" field.
   map<string, string> form_values = 2;
 }
 
-// ExportConfiguration maps to the same message in syncv2. It's a separate
-// message to allow the messages to be changed independently.
-message ExportConfiguration {
-  oneof export {
-    SignedPost signed_post = 1;
+message SleighExportTelemetry {
+  // The files to be exported, passed as a set of already open file descriptors.
+  repeated int32 input_fds = 3;
+
+  oneof export_config {
+    SignedPost signed_post = 4;
   }
+
+  // A set of CEL expressions to use to filter events as they are processed.
+  // If an expression returns true the event is dropped. Expressions can also
+  // redact fields instead of dropping.
+  repeated string filter_expressions = 5;
 }
 
 // SleighConfig contains the configuration data to be passed to Sleigh when
 // Sleigh is started.
 message SleighConfig {
-  // The host_id for this host as sent up to Workshop. This will be used for
+  // The host_id for this host as sent up to Workshop.
   // the export folder.
   string host_id = 1;
 
   // The host_name for this host as sent up to Workshop.
   string host_name = 2;
 
-  // The files to be exported, passed as a set of already open file descriptors.
-  repeated int32 input_fds = 3;
-
-  // Configuration for uploading the converted telemetry files.
-  ExportConfiguration export_config = 4;
-
-  // A set of CEL expressions to use to filter events as they are processed.
-  // If an expression returns true the event is dropped. Expressions can also
-  // redact fields instead of dropping.
-  repeated string filter_expressions = 5;
+  oneof command {
+    SleighExportTelemetry export_telemetry = 3;
+  };
 }


### PR DESCRIPTION
This moves several of the existing fields out of the top-level SleighConfig message into a submessage that is then moved into a oneof to differentiate what kind of action Sleigh is running. It also removes the needless ExportConfiguration wrapper message.

This is a breaking change but as Santa & Sleigh releases are fixed in a release this is acceptable.