### PR TITLE
syncv2: prefix NetworkFlowSocketFamily enum values

### DIFF
--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1344,13 +1344,14 @@ enum NetworkFlowDirection {
 }
 
 // Socket address family for a network flow. Values match Darwin's AF_*
-// constants. Proto3 preserves unknown enum values on the wire, so any
-// family not yet named here (e.g. AF_NDRV = 27) would still round-trip
-// as the raw integer if NEFilterSocketFlow ever delivers it.
+// constants (AF_INET = 2, AF_INET6 = 30). Proto3 preserves unknown enum
+// values on the wire, so any family not yet named here (e.g. AF_NDRV = 27)
+// would still round-trip as the raw integer if NEFilterSocketFlow ever
+// delivers it.
 enum NetworkFlowSocketFamily {
   NETWORK_FLOW_SOCKET_FAMILY_UNSPECIFIED = 0;
-  AF_INET = 2;
-  AF_INET6 = 30;
+  NETWORK_FLOW_SOCKET_FAMILY_INET = 2;
+  NETWORK_FLOW_SOCKET_FAMILY_INET6 = 30;
 }
 
 message NetworkFlowRule {


### PR DESCRIPTION
## Summary
- Renames `NetworkFlowSocketFamily`'s `AF_INET`/`AF_INET6` to `NETWORK_FLOW_SOCKET_FAMILY_INET`/`_INET6`.
- The bare names collide with `<sys/socket.h>` macros (`#define AF_INET 2`), so generated `v2.pb.h` fails to compile in any C++ translation unit that also includes `socket.h` — the preprocessor rewrites the enumerator token to `2 = 2` before the compiler sees the namespace. (Hit in santa via `SNTSyncRuleDownloadTest`.)
- Prefixing also brings the enum in line with the `ENUM_VALUE_PREFIX` convention already used by the sibling `NetworkFlow*` enums.

## Compatibility
Wire values (2, 30) are unchanged — this is a source-only rename of the generated enum symbols. There are currently no consumers of this schema (santa has not yet bumped its protos pin; the santanetd `NetworkFlowEvent` path is unbuilt), so the breaking symbol rename is acceptable.

This unblocks the santa-side protos bump in https://github.com/northpolesec/santa/pull/973's follow-up phase.

## Test plan
- [x] `buf build` clean
- [x] `buf lint` clean (now satisfies `ENUM_VALUE_PREFIX`)
- [x] `buf format` clean