### PR TITLE
syncv2: add dns_upstream_timeout_seconds to NetworkExtension

### DIFF
--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -284,6 +284,11 @@ message NetworkExtension {
 
   // Default action applied to flows that no NetworkFlowRule matches.
   NetworkFlowDefaultAction flow_default_action = 2;
+
+  // Upstream DNS forward timeout used by santanetd's DNS proxy, in seconds.
+  // The client clamps this to [1, 15]s; an unset/0 value uses the client
+  // default (5s).
+  optional double dns_upstream_timeout_seconds = 3;
 }
 
 // Action to apply to network flows that match no NetworkFlowRule.


### PR DESCRIPTION
Adds an optional `dns_upstream_timeout_seconds` field to the `NetworkExtension` message so a sync server can configure the upstream DNS forward timeout used by santanetd's DNS proxy.

The client clamps the value to [1, 15]s; an unset or 0 value falls back to the client default (5s). Uses `double` to preserve fractional-second values end-to-end.