### PR TITLE
telemetry: add needed `duration_proto` dependency

### DIFF
--- a/telemetry/BUILD
+++ b/telemetry/BUILD
@@ -22,6 +22,9 @@ proto_library(
     name = "sleighconfig_proto",
     srcs = ["sleighconfig.proto"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@protobuf//:duration_proto",
+    ],
 )
 
 cc_proto_library(


### PR DESCRIPTION
Fixes santa build when we pin it's protos on current `HEAD` 