### PR TITLE
build: fix missing deps in `telemetry`

### DIFF
--- a/telemetry/BUILD
+++ b/telemetry/BUILD
@@ -23,6 +23,9 @@ proto_library(
     srcs = ["sleighconfig.proto"],
     visibility = ["//visibility:public"],
     deps = [
+        ":v1_proto",
+        "//commands:v1_proto",
+        "//common:signals_proto",
         "@protobuf//:duration_proto",
     ],
 )


### PR DESCRIPTION
Missed these in the last PR