### PR TITLE
syncv2: Move telemetry signals to ruledownload

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main

--- a/sync/v1.proto
+++ b/sync/v1.proto
@@ -988,7 +988,7 @@ message RuleDownloadResponse {
   string cursor = 2;
 
   // Provided by sync v2
-  reserved 3, 4;
+  reserved 3 to 5;
 }
 
 message PostflightRequest {
@@ -1011,9 +1011,9 @@ message PostflightRequest {
   string rules_hash = 5;
 
   // Provided by sync v2
-  reserved 6 to 11;
+  reserved 6 to 14;
 
-  // next ID: 12
+  // next ID: 15
 }
 
 message PostflightResponse {}

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -511,11 +511,6 @@ message PreflightResponse {
   // A set of CEL expressions to apply to telemetry before upload.
   repeated string telemetry_filter_expressions = 35;
 
-  // Non-destructive detection signals to evaluate against telemetry. Santa
-  // passes these through to sleigh's SleighSignalScan.signals, which it triggers
-  // on demand.
-  repeated santa.common.v1.Signal telemetry_signals = 38;
-
   // These fields are deprecated forms of other fields and exist here solely for
   // backwards compatibility.
   optional bool deprecated_enabled_transitive_whitelisting = 1000 [
@@ -1674,6 +1669,11 @@ message RuleDownloadResponse {
 
   // The set of network flow rules in this response.
   repeated NetworkFlowRule network_flow_rules = 4 [json_name = "network_flow_rules"];
+
+  // Non-destructive detection signals to evaluate against telemetry. Santa
+  // passes these through to sleigh's SleighSignalScan.signals, which it triggers
+  // on demand.
+  repeated santa.common.v1.Signal telemetry_signals = 5 [json_name = "telemetry_signals"];
 }
 
 message PostflightRequest {
@@ -1715,7 +1715,17 @@ message PostflightRequest {
   // Hash of network flow rules.
   string network_flow_rules_hash = 11 [json_name = "network_flow_rules_hash"];
 
-  // next ID: 12
+  // The total number of telemetry signals that were received by the client
+  // across all RuleDownload requests.
+  uint32 telemetry_signals_received = 12 [json_name = "telemetry_signals_received"];
+
+  // The number of valid telemetry signals that were successfully imported.
+  uint32 telemetry_signals_processed = 13 [json_name = "telemetry_signals_processed"];
+
+  // Hash of telemetry signals.
+  string telemetry_signals_hash = 14 [json_name = "telemetry_signals_hash"];
+
+  // next ID: 15
 }
 
 message PostflightResponse {}

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1640,6 +1640,25 @@ message NetworkFlowRule {
   }
 }
 
+// TelemetrySignalRule adds or removes a single detection signal, mirroring the
+// add/remove semantics of NetworkFlowRule. The client applies these
+// incrementally across RuleDownload responses.
+message TelemetrySignalRule {
+  message Add {
+    santa.common.v1.Signal signal = 1;
+  }
+
+  message Remove {
+    // The Signal.name to remove.
+    string name = 1;
+  }
+
+  oneof action {
+    Add add = 1;
+    Remove remove = 2;
+  }
+}
+
 message RuleDownloadRequest {
   // When Santa downloads rules from the server, the server can return a
   // "cursor" that is sent back in the next request. This can be used to
@@ -1670,10 +1689,10 @@ message RuleDownloadResponse {
   // The set of network flow rules in this response.
   repeated NetworkFlowRule network_flow_rules = 4 [json_name = "network_flow_rules"];
 
-  // Non-destructive detection signals to evaluate against telemetry. Santa
-  // passes these through to sleigh's SleighSignalScan.signals, which it triggers
-  // on demand.
-  repeated santa.common.v1.Signal telemetry_signals = 5 [json_name = "telemetry_signals"];
+  // Non-destructive detection signal rules to add or remove. Santa passes the
+  // resulting signal set through to sleigh's SleighSignalScan.signals, which it
+  // triggers on demand.
+  repeated TelemetrySignalRule telemetry_signal_rules = 5 [json_name = "telemetry_signal_rules"];
 }
 
 message PostflightRequest {
@@ -1715,15 +1734,15 @@ message PostflightRequest {
   // Hash of network flow rules.
   string network_flow_rules_hash = 11 [json_name = "network_flow_rules_hash"];
 
-  // The total number of telemetry signals that were received by the client
+  // The total number of telemetry signal rules that were received by the client
   // across all RuleDownload requests.
-  uint32 telemetry_signals_received = 12 [json_name = "telemetry_signals_received"];
+  uint32 telemetry_signal_rules_received = 12 [json_name = "telemetry_signal_rules_received"];
 
-  // The number of valid telemetry signals that were successfully imported.
-  uint32 telemetry_signals_processed = 13 [json_name = "telemetry_signals_processed"];
+  // The number of valid telemetry signal rules that were successfully imported.
+  uint32 telemetry_signal_rules_processed = 13 [json_name = "telemetry_signal_rules_processed"];
 
-  // Hash of telemetry signals.
-  string telemetry_signals_hash = 14 [json_name = "telemetry_signals_hash"];
+  // Hash of telemetry signal rules.
+  string telemetry_signal_rules_hash = 14 [json_name = "telemetry_signal_rules_hash"];
 
   // next ID: 15
 }

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1640,9 +1640,8 @@ message NetworkFlowRule {
   }
 }
 
-// TelemetrySignalRule adds or removes a single detection signal, mirroring the
-// add/remove semantics of NetworkFlowRule. The client applies these
-// incrementally across RuleDownload responses.
+// TelemetrySignalRule adds or removes a single detection signal. The client
+// applies these incrementally across RuleDownload responses.
 message TelemetrySignalRule {
   message Add {
     santa.common.v1.Signal signal = 1;


### PR DESCRIPTION
This is not a safe change but the removed fields have not shipped

Part of WS-787