### PR TITLE
syncv2: Add total_competing_rule_count to NetworkFlowEvent

### DIFF
--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1042,6 +1042,10 @@ message NetworkFlowEvent {
   // Other rules that also matched but were not chosen (for telemetry).
   repeated int64 competing_rule_ids = 11;
 
+  // Total number of distinct competing rules that matched (winner excluded,
+  // deduped). competing_rule_ids lists the highest-precedence subset of these.
+  uint32 total_competing_rule_count = 15;
+
   // Wall-clock time of the flow decision (seconds since epoch, fractional).
   double flow_time = 12;
 
@@ -1052,6 +1056,8 @@ message NetworkFlowEvent {
 
   // The process that delegated the flow on behalf of another (e.g. mDNSResponder).
   optional Process via_process = 14;
+
+  // next ID: 16
 }
 
 // Audit Event for when Santa makes a new rule in standalone mode.


### PR DESCRIPTION
Adds `total_competing_rule_count` to `NetworkFlowEvent` — the total number of distinct competing rules that matched, which the capped `competing_rule_ids` list cannot reconstruct on its own. Additive field (number 15), non-breaking.