### PR TITLE
signals: Remove the description field

### DIFF
--- a/common/signals.proto
+++ b/common/signals.proto
@@ -40,11 +40,9 @@ message Signal {
   // Stable identifier for the signal (e.g. "CRED-001"), echoed in the report.
   string name = 1;
 
-  // Human-readable description of what the signal detects.
-  string description = 2;
-
-  Severity severity = 3;
+  // An attached severity for the signal.
+  Severity severity = 2;
 
   // CEL boolean expression over `event`. A true result is a match.
-  string expression = 4;
+  string expression = 3;
 }

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1325,13 +1325,9 @@ message SignalReport {
 
   santa.common.v1.Severity severity = 2;
 
-  // The Signal.description, echoed for convenience so alerting does not need to
-  // re-join against the synced config.
-  string description = 3;
-
   // One entry per time this signal fired during the scan. The number of matches
   // is the total match count.
-  repeated Match matches = 4;
+  repeated Match matches = 3;
 
   // A single firing of the signal.
   message Match {


### PR DESCRIPTION
The dropped field and renumber is OK, we haven't shipped this yet.