### PR TITLE
signals: Add ancestors

### DIFF
--- a/common/signals.proto
+++ b/common/signals.proto
@@ -46,3 +46,54 @@ message Signal {
   // CEL boolean expression over `event`. A true result is a match.
   string expression = 3;
 }
+
+// SignalReport summarizes how a single detection signal matched over the course
+// of a signal scan. One entry is emitted per signal that fired at least once.
+// Shared by sleigh's scan response (santa.telemetry.v1) and the sync upload
+// (santa.sync.v2) so the two stay identical.
+message SignalReport {
+  // The Signal.name that fired.
+  string name = 1;
+
+  Severity severity = 2;
+
+  // One entry per time this signal fired during the scan. The number of matches
+  // is the total match count.
+  repeated Match matches = 3;
+
+  // A single firing of the signal.
+  message Match {
+    // The source event(s) that triggered this match. A signal currently fires
+    // on a single event, but this is repeated to allow signals that join across
+    // related events in the future. Each ID is the event type and the event ID
+    // separated by a colon (e.g. "execution:<id>").
+    repeated string event_ids = 1;
+
+    // The ancestry of the process the matched event pertains to, reconstructed
+    // from the process tree sleigh builds from fork/exec/exit telemetry. Element
+    // 0 is the process itself, element 1 its parent, and so on to the root.
+    repeated SignalProcessNode process_tree = 2;
+  }
+}
+
+// SignalProcessNode is one process in a match's process tree. Identity (pid,
+// pidversion, path) is always present; the code signature, platform flag,
+// responsible id, and args are known only for processes observed executing —
+// they are empty for processes seen only via fork/exit or synthesized as a
+// parent stub. Envs are populated only on element 0 (the matched process).
+message SignalProcessNode {
+  int32 pid = 1;
+  int32 pidversion = 2;
+  string path = 3;
+  bool exited = 4;
+  bool is_platform_binary = 5;
+  int32 responsible_pid = 6;
+  int32 responsible_pidversion = 7;
+  // Code signature of the executable: team id, the formatted signing id
+  // (platform:/TEAMID: prefixed), and the hex-encoded cdhash.
+  string team_id = 8;
+  string signing_id = 9;
+  string cdhash = 10;
+  repeated string args = 11;
+  repeated string envs = 12;
+}

--- a/syncv2/v2.proto
+++ b/syncv2/v2.proto
@@ -1326,37 +1326,14 @@ message EventUploadResponse {
   repeated string event_upload_bundle_binaries = 1;
 }
 
-// SignalReport summarizes how a single detection signal matched over the course
-// of a signal scan. Mirrors santa.telemetry.v1.SignalReport (it's a separate
-// message to allow the two to be changed independently). One entry is emitted
-// per signal that fired at least once.
-message SignalReport {
-  // The Signal.name that fired.
-  string name = 1;
-
-  santa.common.v1.Severity severity = 2;
-
-  // One entry per time this signal fired during the scan. The number of matches
-  // is the total match count.
-  repeated Match matches = 3;
-
-  // A single firing of the signal.
-  message Match {
-    // The source event(s) that triggered this match. A signal currently fires
-    // on a single event, but this is repeated to allow signals that join across
-    // related events in the future. Each ID is the event type and the event ID
-    // separated by a colon (e.g. "execution:<id>").
-    repeated string event_ids = 1;
-  }
-}
-
 message SignalUploadRequest {
   // The UUID of the machine where the signals fired. See the comment above the
   // same field in `PreflightRequest` for more details.
   string machine_id = 1 [json_name = "machine_id"];
 
-  // The set of signal reports being uploaded.
-  repeated SignalReport signal_reports = 2 [json_name = "signal_reports"];
+  // The set of signal reports being uploaded. SignalReport lives in
+  // santa.common.v1, shared with sleigh's scan response.
+  repeated santa.common.v1.SignalReport signal_reports = 2 [json_name = "signal_reports"];
 }
 
 message SignalUploadResponse {}

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -65,6 +65,12 @@ message SleighSignalScan {
   // one event is summarized in the SleighResponse signal report. Sourced by
   // santa from the synced telemetry_signals config.
   repeated santa.common.v1.Signal signals = 2;
+
+  // Sleigh's persistent scan-state database, passed as an already-open
+  // read-write file descriptor. Santa opens it as root (the file lives under
+  // root-owned /var/db/santa) and hands the fd to sleigh, which runs with
+  // dropped privileges but keeps the inherited descriptor.
+  int32 state_db_fd = 3;
 }
 
 // BinaryMetadata is computed by santa (via SNTFileInfo + MOLCodesignChecker) and
@@ -208,32 +214,11 @@ message SleighConfig {
   }
 }
 
-// SignalReport summarizes how a single detection signal matched over the course
-// of a signal scan. One entry is emitted per signal that fired at least once.
-message SignalReport {
-  // The Signal.name that fired.
-  string name = 1;
-
-  santa.common.v1.Severity severity = 2;
-
-  // One entry per time this signal fired during the scan. The number of matches
-  // is the total match count.
-  repeated Match matches = 3;
-
-  // A single firing of the signal.
-  message Match {
-    // The source event(s) that triggered this match. A signal currently fires
-    // on a single event, but this is repeated to allow signals that join across
-    // related events in the future. Each ID is the event type and the event ID
-    // separated by a colon (e.g. "execution:<id>").
-    repeated string event_ids = 1;
-  }
-}
-
 // SleighSignalScanResponse is the result of a signal_scan command.
 message SleighSignalScanResponse {
   // One entry per detection signal that fired at least once, sorted by name.
-  repeated SignalReport signal_reports = 1;
+  // SignalReport lives in santa.common.v1 so this and the sync upload share it.
+  repeated santa.common.v1.SignalReport signal_reports = 1;
 }
 
 // SleighResponse is written (serialized) to stdout by sleigh and read by santad.


### PR DESCRIPTION
Also merge both SignalReport messages into the shared signals.proto to avoid duplication.

This change is fully wire-compatible. Skipping the buf breaking step because it's (potentially) not source-compatible but that's OK.