### PR TITLE
signals: Add filters & responsible processes

### DIFF
--- a/common/signals.proto
+++ b/common/signals.proto
@@ -73,6 +73,14 @@ message SignalReport {
     // from the process tree sleigh builds from fork/exec/exit telemetry. Element
     // 0 is the process itself, element 1 its parent, and so on to the root.
     repeated SignalProcessNode process_tree = 2;
+
+    // Full details for responsible processes referenced by a process_tree node's
+    // responsible_pid/responsible_pidversion that are not themselves in
+    // process_tree (e.g. the app that launched a helper via LaunchServices). To
+    // resolve a node's responsible process, join its responsible_pid/pidversion
+    // against process_tree first, then here. Kept separate from process_tree so a
+    // node's role (ancestor vs. responsible) is never ambiguous.
+    repeated SignalProcessNode responsible_processes = 3;
   }
 }
 

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -71,6 +71,11 @@ message SleighSignalScan {
   // root-owned /var/db/santa) and hands the fd to sleigh, which runs with
   // dropped privileges but keeps the inherited descriptor.
   int32 state_db_fd = 3;
+
+  // A set of CEL expressions to use to filter events as they are processed.
+  // If an expression returns true a matched process will not upload envs/args.
+  // Expressions can also redact fields instead of dropping.
+  repeated string filter_expressions = 5;
 }
 
 // BinaryMetadata is computed by santa (via SNTFileInfo + MOLCodesignChecker) and


### PR DESCRIPTION
Add filter expressions so that when a process is uploaded in a signal report, we can still redact or drop its args/envs from being uploaded.

Add responsible processes as a second repeated set - if the responsible process for a process doesn't already appear in the ancestry tree it can be found in this list and referenced later.