### PR TITLE
sleigh: Add command for inventory scans

### DIFF
--- a/commands/BUILD
+++ b/commands/BUILD
@@ -6,7 +6,7 @@ proto_library(
     name = "v1_proto",
     srcs = ["v1.proto"],
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = ["//common:inventory_proto"],
 )
 
 cc_proto_library(

--- a/commands/v1.proto
+++ b/commands/v1.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package santa.commands.v1;
 
+import "common/inventory.proto";
+
 option go_package = "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/commands";
 
 message RunningProcess {
@@ -140,6 +142,32 @@ message BinaryUploadResponse {
   optional int64 upload_duration_ms = 5 [json_name = "upload_duration_ms"];
 }
 
+// Command to request Santa run a read-only package-inventory scan (via sleigh)
+// and upload the results to the workshop-minted presigned POST. Santa forwards
+// `scan` and `signed_post` into the SleighInventoryScan it hands to sleigh.
+message InventoryScanRequest {
+  // Scan tuning parameters (profile, roots, ecosystems, limits, ...). Shared
+  // with the SleighConfig command sleigh runs (SleighInventoryScan).
+  santa.common.v1.InventoryScan scan = 1;
+
+  // Presigned POST minted by workshop for the results zip. Santa forwards this
+  // to sleigh verbatim; the object key is baked into form_values["key"].
+  SignedPost signed_post = 2 [json_name = "signed_post"];
+}
+
+// Results are uploaded directly to the presigned POST (like binary upload), so
+// this only reports command-level success/failure.
+message InventoryScanResponse {
+  enum Error {
+    ERROR_UNSPECIFIED = 0;
+    // Santa/sleigh failed to run the scan (spawn, parse, internal error).
+    ERROR_INTERNAL = 1;
+    // The scan ran but uploading the results to the presigned POST failed.
+    ERROR_UPLOAD_FAILED = 2;
+  }
+  optional Error error = 1;
+}
+
 // Command message sent to santa.host.<deviceid>.commands
 message SantaCommandRequest {
   // Nonce
@@ -160,6 +188,7 @@ message SantaCommandRequest {
     KillRequest kill = 11;
     EventUploadRequest event_upload = 12;
     BinaryUploadRequest binary_upload = 13;
+    InventoryScanRequest inventory_scan = 14;
   }
 }
 
@@ -180,6 +209,7 @@ message SantaCommandResponse {
     KillResponse kill = 3;
     EventUploadResponse event_upload = 4;
     BinaryUploadResponse binary_upload = 5;
+    InventoryScanResponse inventory_scan = 6;
   }
 }
 

--- a/common/BUILD
+++ b/common/BUILD
@@ -14,3 +14,16 @@ cc_proto_library(
     deps = [":signals_proto"],
     visibility = ["//visibility:public"],
 )
+
+proto_library(
+    name = "inventory_proto",
+    srcs = ["inventory.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["@protobuf//:duration_proto"],
+)
+
+cc_proto_library(
+    name = "inventory_cc_proto",
+    deps = [":inventory_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/common/inventory.proto
+++ b/common/inventory.proto
@@ -1,0 +1,106 @@
+/// Copyright 2026 North Pole Security, Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+syntax = "proto3";
+
+package santa.common.v1;
+
+import "google/protobuf/duration.proto";
+
+option go_package = "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/common";
+option objc_class_prefix = "SNTPB";
+
+// InventoryScan carries the tuning parameters for a read-only package-inventory
+// discovery sweep. No package managers are executed and no resolution-time
+// network requests are made; sleigh only reads on-disk lockfiles and install
+// metadata.
+//
+// Shared between the SleighConfig command sleigh actually runs
+// (santa.telemetry.v1.SleighInventoryScan) and the workshop-issued host command
+// (santa.commands.v1.InventoryScanRequest) so the tunable surface stays
+// identical. Transport details (the presigned upload target, host_id /
+// host_name) live on those wrappers, not here.
+message InventoryScan {
+  // Discovery profile.
+  enum Profile {
+    // Unset; sleigh treats this as PROFILE_BASELINE.
+    PROFILE_UNKNOWN = 0;
+    // Bounded known package/tool roots (the default fleet scan).
+    PROFILE_BASELINE = 1;
+    // Configured developer/project roots.
+    PROFILE_PROJECT = 2;
+    // Incident-response exposure scan; requires explicit roots and may
+    // include user home directories.
+    PROFILE_DEEP = 3;
+  }
+
+  // Package ecosystem identifiers, matching sleigh's emitted ecosystem
+  // strings.
+  enum Ecosystem {
+    ECOSYSTEM_UNKNOWN = 0;
+    ECOSYSTEM_NPM = 1;
+    ECOSYSTEM_PYPI = 2;
+    ECOSYSTEM_GO = 3;
+    ECOSYSTEM_RUBYGEMS = 4;
+    ECOSYSTEM_PACKAGIST = 5;
+    ECOSYSTEM_MCP = 6;
+    ECOSYSTEM_EDITOR_EXTENSION = 7;
+    ECOSYSTEM_BROWSER_EXTENSION = 8;
+  }
+
+  // Discovery profile. Unset (PROFILE_UNKNOWN) is treated as
+  // PROFILE_BASELINE, the default fleet scan.
+  Profile profile = 1;
+
+  // Filesystem roots to scan. Required for PROFILE_DEEP; optional for
+  // PROFILE_BASELINE and PROFILE_PROJECT (in which case profile-curated
+  // defaults are used). Unrelated to running the binary as root.
+  repeated string roots = 2;
+
+  // Additional directory names or suffix paths to exclude during walking,
+  // on top of the built-in walker excludes.
+  repeated string excludes = 3;
+
+  // Restrict scanning to these ecosystems. When empty all supported
+  // ecosystems run.
+  repeated Ecosystem ecosystems = 4;
+
+  // macOS only: when true, baseline/project per-user roots are expanded
+  // across every real /Users/<name>/ home (useful when sleigh runs as a
+  // root LaunchDaemon). Cannot be combined with PROFILE_DEEP or with
+  // operator-supplied roots. No effect on Linux.
+  bool all_users = 5;
+
+  // Per-file read cap in bytes. 0 falls back to sleigh's built-in default.
+  int64 max_file_size = 6;
+
+  // Wall-clock budget for the whole scan. Zero / unset means unbounded.
+  google.protobuf.Duration max_duration = 7;
+
+  // Concurrent file parsers. 0 falls back to sleigh's built-in default.
+  int32 concurrency = 8;
+
+  // Path to a JSON exposure catalog file or directory of *.json catalogs
+  // (merged non-recursively). Matches emit record_type=finding alongside
+  // package records.
+  string exposure_catalog_path = 9;
+
+  // Per-catalog-file read cap in bytes. 0 falls back to sleigh's
+  // built-in default.
+  int64 max_catalog_size = 10;
+
+  // Suppress package records while still emitting findings and the
+  // scan_summary. Requires exposure_catalog_path to be set.
+  bool findings_only = 11;
+}

--- a/telemetry/BUILD
+++ b/telemetry/BUILD
@@ -25,8 +25,8 @@ proto_library(
     deps = [
         ":v1_proto",
         "//commands:v1_proto",
+        "//common:inventory_proto",
         "//common:signals_proto",
-        "@protobuf//:duration_proto",
     ],
 )
 

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -17,8 +17,8 @@ syntax = "proto3";
 package santa.telemetry.v1;
 
 import "commands/v1.proto";
+import "common/inventory.proto";
 import "common/signals.proto";
-import "google/protobuf/duration.proto";
 import "telemetry/v1.proto";
 
 option go_package = "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/telemetry";
@@ -125,81 +125,13 @@ message SleighBinaryUpload {
 // lockfiles and install metadata. host_id / host_name come from the
 // SleighConfig wrapper and are stamped on every emitted row.
 message SleighInventoryScan {
-  // Discovery profile.
-  enum Profile {
-    // Unset; sleigh treats this as PROFILE_BASELINE.
-    PROFILE_UNKNOWN = 0;
-    // Bounded known package/tool roots (the default fleet scan).
-    PROFILE_BASELINE = 1;
-    // Configured developer/project roots.
-    PROFILE_PROJECT = 2;
-    // Incident-response exposure scan; requires explicit roots and may
-    // include user home directories.
-    PROFILE_DEEP = 3;
-  }
-
-  // Package ecosystem identifiers, matching sleigh's emitted ecosystem
-  // strings.
-  enum Ecosystem {
-    ECOSYSTEM_UNKNOWN = 0;
-    ECOSYSTEM_NPM = 1;
-    ECOSYSTEM_PYPI = 2;
-    ECOSYSTEM_GO = 3;
-    ECOSYSTEM_RUBYGEMS = 4;
-    ECOSYSTEM_PACKAGIST = 5;
-    ECOSYSTEM_MCP = 6;
-    ECOSYSTEM_EDITOR_EXTENSION = 7;
-    ECOSYSTEM_BROWSER_EXTENSION = 8;
-  }
-
-  // Discovery profile. Unset (PROFILE_UNKNOWN) is treated as
-  // PROFILE_BASELINE, the default fleet scan.
-  Profile profile = 1;
-
-  // Filesystem roots to scan. Required for PROFILE_DEEP; optional for
-  // PROFILE_BASELINE and PROFILE_PROJECT (in which case profile-curated
-  // defaults are used). Unrelated to running the binary as root.
-  repeated string roots = 2;
-
-  // Additional directory names or suffix paths to exclude during walking,
-  // on top of the built-in walker excludes.
-  repeated string excludes = 3;
-
-  // Restrict scanning to these ecosystems. When empty all supported
-  // ecosystems run.
-  repeated Ecosystem ecosystems = 4;
-
-  // macOS only: when true, baseline/project per-user roots are expanded
-  // across every real /Users/<name>/ home (useful when sleigh runs as a
-  // root LaunchDaemon). Cannot be combined with PROFILE_DEEP or with
-  // operator-supplied roots. No effect on Linux.
-  bool all_users = 5;
-
-  // Per-file read cap in bytes. 0 falls back to sleigh's built-in default.
-  int64 max_file_size = 6;
-
-  // Wall-clock budget for the whole scan. Zero / unset means unbounded.
-  google.protobuf.Duration max_duration = 7;
-
-  // Concurrent file parsers. 0 falls back to sleigh's built-in default.
-  int32 concurrency = 8;
-
-  // Path to a JSON exposure catalog file or directory of *.json catalogs
-  // (merged non-recursively). Matches emit record_type=finding alongside
-  // package records.
-  string exposure_catalog_path = 9;
-
-  // Per-catalog-file read cap in bytes. 0 falls back to sleigh's
-  // built-in default.
-  int64 max_catalog_size = 10;
-
-  // Suppress package records while still emitting findings and the
-  // scan_summary. Requires exposure_catalog_path to be set.
-  bool findings_only = 11;
+  // Scan tuning parameters (profile, roots, ecosystems, limits, ...). Shared
+  // with the workshop-issued host command (santa.commands.v1.InventoryScanRequest).
+  santa.common.v1.InventoryScan scan = 1;
 
   // Presigned POST minted by workshop. The object key is built from
   // form_values["key"] suffixed by the run's generated filename.
-  SignedPost signed_post = 12;
+  SignedPost signed_post = 2;
 }
 
 // SleighConfig contains the configuration data to be passed to Sleigh when


### PR DESCRIPTION
Skipping buf breaking: this moves most fields out of SleighInventoryScan into a shared message that is also used by the command. As nothing is currently calling SleighInventoryScan, this is OK.

Part of WS-1275