### PR TITLE
commands: Add binary upload & inventory scan to queued commands

### DIFF
--- a/commands/v1.proto
+++ b/commands/v1.proto
@@ -231,6 +231,8 @@ message QueuedCommand {
   oneof command {
     KillRequest kill = 2;
     EventUploadRequest event_upload = 3;
+    BinaryUploadRequest binary_upload = 4;
+    InventoryScanRequest inventory_scan = 5;
   }
 }
 
@@ -270,6 +272,8 @@ message CommandResult {
   oneof result {
     KillResponse kill = 4;
     EventUploadResponse event_upload = 5;
+    BinaryUploadResponse binary_upload = 6;
+    InventoryScanResponse inventory_scan = 7;
   }
 }
 


### PR DESCRIPTION
Wires the existing `BinaryUpload{Request,Response}` and `InventoryScan{Request,Response}` messages into the sync-pull command path, so these two commands can be delivered via `QueuedCommand` and reported via `CommandResult` — not just pushed through `SantaCommandRequest`/`Response`.

No new message types and no renumbering: these are additive oneof fields only (`binary_upload`/`inventory_scan` at 4/5 in `QueuedCommand.command`, 6/7 in `CommandResult.result`). Both commands upload their bulk payload out-of-band to the presigned `signed_post` in the request, so the `CommandResult` variant only carries upload status.

`buf build` succeeds and `buf breaking --against origin/main` passes clean.