### PR TITLE
packageinventory: Rename inventory scan to package inventory

### DIFF
--- a/commands/BUILD
+++ b/commands/BUILD
@@ -6,7 +6,7 @@ proto_library(
     name = "v1_proto",
     srcs = ["v1.proto"],
     visibility = ["//visibility:public"],
-    deps = ["//common:inventory_proto"],
+    deps = ["//common:packageinventory_proto"],
 )
 
 cc_proto_library(

--- a/commands/v1.proto
+++ b/commands/v1.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package santa.commands.v1;
 
-import "common/inventory.proto";
+import "common/packageinventory.proto";
 
 option go_package = "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/commands";
 
@@ -144,11 +144,12 @@ message BinaryUploadResponse {
 
 // Command to request Santa run a read-only package-inventory scan (via sleigh)
 // and upload the results to the workshop-minted presigned POST. Santa forwards
-// `scan` and `signed_post` into the SleighInventoryScan it hands to sleigh.
-message InventoryScanRequest {
+// `scan` and `signed_post` into the SleighPackageInventoryScan it hands to
+// sleigh.
+message PackageInventoryRequest {
   // Scan tuning parameters (profile, roots, ecosystems, limits, ...). Shared
-  // with the SleighConfig command sleigh runs (SleighInventoryScan).
-  santa.common.v1.InventoryScan scan = 1;
+  // with the SleighConfig command sleigh runs (SleighPackageInventoryScan).
+  santa.common.v1.PackageInventoryScan scan = 1;
 
   // Presigned POST minted by workshop for the results zip. Santa forwards this
   // to sleigh verbatim; the object key is baked into form_values["key"].
@@ -157,7 +158,7 @@ message InventoryScanRequest {
 
 // Results are uploaded directly to the presigned POST (like binary upload), so
 // this only reports command-level success/failure.
-message InventoryScanResponse {
+message PackageInventoryResponse {
   enum Error {
     ERROR_UNSPECIFIED = 0;
     // Santa/sleigh failed to run the scan (spawn, parse, internal error).
@@ -188,7 +189,6 @@ message SantaCommandRequest {
     KillRequest kill = 11;
     EventUploadRequest event_upload = 12;
     BinaryUploadRequest binary_upload = 13;
-    InventoryScanRequest inventory_scan = 14;
   }
 }
 
@@ -209,7 +209,6 @@ message SantaCommandResponse {
     KillResponse kill = 3;
     EventUploadResponse event_upload = 4;
     BinaryUploadResponse binary_upload = 5;
-    InventoryScanResponse inventory_scan = 6;
   }
 }
 
@@ -232,7 +231,7 @@ message QueuedCommand {
     KillRequest kill = 2;
     EventUploadRequest event_upload = 3;
     BinaryUploadRequest binary_upload = 4;
-    InventoryScanRequest inventory_scan = 5;
+    PackageInventoryRequest package_inventory = 5;
   }
 }
 
@@ -273,7 +272,7 @@ message CommandResult {
     KillResponse kill = 4;
     EventUploadResponse event_upload = 5;
     BinaryUploadResponse binary_upload = 6;
-    InventoryScanResponse inventory_scan = 7;
+    PackageInventoryResponse package_inventory = 7;
   }
 }
 

--- a/common/BUILD
+++ b/common/BUILD
@@ -16,14 +16,14 @@ cc_proto_library(
 )
 
 proto_library(
-    name = "inventory_proto",
-    srcs = ["inventory.proto"],
+    name = "packageinventory_proto",
+    srcs = ["packageinventory.proto"],
     visibility = ["//visibility:public"],
     deps = ["@protobuf//:duration_proto"],
 )
 
 cc_proto_library(
-    name = "inventory_cc_proto",
-    deps = [":inventory_proto"],
+    name = "packageinventory_cc_proto",
+    deps = [":packageinventory_proto"],
     visibility = ["//visibility:public"],
 )

--- a/common/packageinventory.proto
+++ b/common/packageinventory.proto
@@ -21,17 +21,17 @@ import "google/protobuf/duration.proto";
 option go_package = "buf.build/gen/go/northpolesec/protos/protocolbuffers/go/common";
 option objc_class_prefix = "SNTPB";
 
-// InventoryScan carries the tuning parameters for a read-only package-inventory
-// discovery sweep. No package managers are executed and no resolution-time
-// network requests are made; sleigh only reads on-disk lockfiles and install
-// metadata.
+// PackageInventoryScan carries the tuning parameters for a read-only
+// package-inventory discovery sweep. No package managers are executed and no
+// resolution-time network requests are made; sleigh only reads on-disk
+// lockfiles and install metadata.
 //
 // Shared between the SleighConfig command sleigh actually runs
-// (santa.telemetry.v1.SleighInventoryScan) and the workshop-issued host command
-// (santa.commands.v1.InventoryScanRequest) so the tunable surface stays
-// identical. Transport details (the presigned upload target, host_id /
+// (santa.telemetry.v1.SleighPackageInventoryScan) and the workshop-issued host
+// command (santa.commands.v1.PackageInventoryRequest) so the tunable surface
+// stays identical. Transport details (the presigned upload target, host_id /
 // host_name) live on those wrappers, not here.
-message InventoryScan {
+message PackageInventoryScan {
   // Discovery profile.
   enum Profile {
     // Unset; sleigh treats this as PROFILE_BASELINE.
@@ -84,25 +84,6 @@ message InventoryScan {
   // operator-supplied roots. No effect on Linux.
   bool all_users = 5;
 
-  // Per-file read cap in bytes. 0 falls back to sleigh's built-in default.
-  int64 max_file_size = 6;
-
   // Wall-clock budget for the whole scan. Zero / unset means unbounded.
-  google.protobuf.Duration max_duration = 7;
-
-  // Concurrent file parsers. 0 falls back to sleigh's built-in default.
-  int32 concurrency = 8;
-
-  // Path to a JSON exposure catalog file or directory of *.json catalogs
-  // (merged non-recursively). Matches emit record_type=finding alongside
-  // package records.
-  string exposure_catalog_path = 9;
-
-  // Per-catalog-file read cap in bytes. 0 falls back to sleigh's
-  // built-in default.
-  int64 max_catalog_size = 10;
-
-  // Suppress package records while still emitting findings and the
-  // scan_summary. Requires exposure_catalog_path to be set.
-  bool findings_only = 11;
+  google.protobuf.Duration max_duration = 6;
 }

--- a/telemetry/BUILD
+++ b/telemetry/BUILD
@@ -25,7 +25,7 @@ proto_library(
     deps = [
         ":v1_proto",
         "//commands:v1_proto",
-        "//common:inventory_proto",
+        "//common:packageinventory_proto",
         "//common:signals_proto",
     ],
 )

--- a/telemetry/sleighconfig.proto
+++ b/telemetry/sleighconfig.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package santa.telemetry.v1;
 
 import "commands/v1.proto";
-import "common/inventory.proto";
+import "common/packageinventory.proto";
 import "common/signals.proto";
 import "telemetry/v1.proto";
 
@@ -118,16 +118,17 @@ message SleighBinaryUpload {
   repeated string filter_expressions = 5;
 }
 
-// SleighInventoryScan runs a read-only package-inventory discovery sweep on
-// the host and uploads per-ecosystem Parquet files inside a zip to a
+// SleighPackageInventoryScan runs a read-only package-inventory discovery sweep
+// on the host and uploads per-ecosystem Parquet files inside a zip to a
 // workshop-minted presigned POST. No package managers are executed and no
 // resolution-time network requests are made; sleigh only reads on-disk
 // lockfiles and install metadata. host_id / host_name come from the
 // SleighConfig wrapper and are stamped on every emitted row.
-message SleighInventoryScan {
+message SleighPackageInventoryScan {
   // Scan tuning parameters (profile, roots, ecosystems, limits, ...). Shared
-  // with the workshop-issued host command (santa.commands.v1.InventoryScanRequest).
-  santa.common.v1.InventoryScan scan = 1;
+  // with the workshop-issued host command
+  // (santa.commands.v1.PackageInventoryRequest).
+  santa.common.v1.PackageInventoryScan scan = 1;
 
   // Presigned POST minted by workshop. The object key is built from
   // form_values["key"] suffixed by the run's generated filename.
@@ -146,7 +147,7 @@ message SleighConfig {
   oneof command {
     SleighExportTelemetry export_telemetry = 3;
     SleighBinaryUpload binary_upload = 4;
-    SleighInventoryScan inventory_scan = 5;
+    SleighPackageInventoryScan package_inventory_scan = 5;
     SleighSignalScan signal_scan = 6;
   }
 }


### PR DESCRIPTION
Renames package inventory messages to avoid confusion with the existing inventory command, moves command handling to the new QueuedCommand mechanism, removes some unused scan fields.